### PR TITLE
Fix missing price bug after webhook update

### DIFF
--- a/graphql/fragments/ProductVariantData.graphql
+++ b/graphql/fragments/ProductVariantData.graphql
@@ -11,6 +11,17 @@ fragment ProductVariantData on ProductVariant {
     }
   }
 
+  channelListings {
+    id
+    channel {
+      slug
+    }
+    price {
+      currency
+      amount
+    }
+  }
+
   attributes {
     ...ProductAttributesData
   }

--- a/src/lib/algolia/algoliaSearchProvider.ts
+++ b/src/lib/algolia/algoliaSearchProvider.ts
@@ -92,6 +92,8 @@ export class AlgoliaSearchProvider implements SearchProvider {
   async updateProductVariant(productVariant: ProductVariantWebhookPayloadFragment) {
     debug(`updateProductVariant called`);
 
+    console.log(">>>>", productVariant);
+
     if (!productVariant.product.channelListings) {
       debug("Product has no channelListings - abort");
       return;
@@ -153,7 +155,10 @@ const groupVariantByIndexName = (
       visibleInListings === null ? true : channelListing.visibleInListings === visibleInListings,
     )
     .map((channelListing) => {
-      const object = productAndVariantToAlgolia(productVariant);
+      const object = productAndVariantToAlgolia({
+        variant: productVariant,
+        channel: channelListing.channel.slug,
+      });
       return {
         object,
         indexName: channelListingToAlgoliaIndexId(channelListing, indexNamePrefix),

--- a/src/lib/algolia/algoliaSearchProvider.ts
+++ b/src/lib/algolia/algoliaSearchProvider.ts
@@ -92,8 +92,6 @@ export class AlgoliaSearchProvider implements SearchProvider {
   async updateProductVariant(productVariant: ProductVariantWebhookPayloadFragment) {
     debug(`updateProductVariant called`);
 
-    console.log(">>>>", productVariant);
-
     if (!productVariant.product.channelListings) {
       debug("Product has no channelListings - abort");
       return;

--- a/src/lib/algolia/algoliaUtils.ts
+++ b/src/lib/algolia/algoliaUtils.ts
@@ -56,9 +56,13 @@ export function formatMetadata({ product }: ProductVariantWebhookPayloadFragment
 export type AlgoliaObject = ReturnType<typeof productAndVariantToAlgolia>;
 
 export function productAndVariantToAlgolia({
-  product,
-  ...variant
-}: ProductVariantWebhookPayloadFragment) {
+  variant,
+  channel,
+}: {
+  variant: ProductVariantWebhookPayloadFragment;
+  channel: string;
+}) {
+  const product = variant.product;
   const attributes = {
     ...product.attributes.reduce((acc, attr, idx) => {
       return { ...acc, [attr.attribute.name ?? ""]: attr.values[idx]?.name ?? "" };
@@ -68,8 +72,10 @@ export function productAndVariantToAlgolia({
     }, {}),
   };
 
+  const listing = variant.channelListings?.find((l) => l.channel.slug === channel);
+
   const document = {
-    objectID: productAndVariantToObjectID({ product, ...variant }),
+    objectID: productAndVariantToObjectID(variant),
     productId: product.id,
     variantId: variant.id,
     name: `${product.name} - ${variant.name}`,
@@ -79,10 +85,10 @@ export function productAndVariantToAlgolia({
     description: product.description,
     slug: product.slug,
     thumbnail: product.thumbnail?.url,
-    grossPrice: variant.pricing?.price?.gross?.amount,
-    categories: categoryHierarchicalFacets({ product, ...variant }),
+    grossPrice: listing?.price?.amount,
+    categories: categoryHierarchicalFacets(variant),
     collections: product.collections?.map((collection) => collection.name) || [],
-    metadata: formatMetadata({ product, ...variant }),
+    metadata: formatMetadata(variant),
   };
   return document;
 }


### PR DESCRIPTION
Fixes #20

When theres more than one channel, the price from the pricing field is unavailable causing removing its value after the webhook update.